### PR TITLE
Replace "excerpt" with "description"

### DIFF
--- a/layouts/partials/post-summary-article.html
+++ b/layouts/partials/post-summary-article.html
@@ -14,5 +14,5 @@
         </div>
         {{ partial "author-vcard.html" . }}
     </div>
-    <p>{{ with .Params.excerpt }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ end }}{{ end }}</p>
+    <p>{{ with .Params.description }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ end }}{{ end }}</p>
 </article>

--- a/layouts/partials/recent-posts.html
+++ b/layouts/partials/recent-posts.html
@@ -17,7 +17,7 @@
             </div>
             {{ partial "author-vcard.html" . }}
         </div>
-        <p>{{ with .Params.excerpt }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ end }}{{ end }}</p>
+        <p>{{ with .Params.description }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ end }}{{ end }}</p>
     </article>
     </a>
     {{ end }}


### PR DESCRIPTION
Note: In Hugo, "description" is used for Twitter cards (https://gohugo.io/templates/internal/#twitter-cards)