### PR TITLE
Upgrade to Boostrap 5.1.3

### DIFF
--- a/assets/scss/techtoolbox-bootstrap.scss
+++ b/assets/scss/techtoolbox-bootstrap.scss
@@ -59,6 +59,8 @@ $breadcrumb-padding-x: 0.5rem;
 @import "../../node_modules/bootstrap/scss/popover";
 @import "../../node_modules/bootstrap/scss/carousel";
 @import "../../node_modules/bootstrap/scss/spinners";
+@import "../../node_modules/bootstrap/scss/offcanvas";
+@import "../../node_modules/bootstrap/scss/placeholders";
 
 // Helpers
 @import "../../node_modules/bootstrap/scss/helpers";

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "bootstrap": {
-      "version": "5.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0-beta2.tgz",
-      "integrity": "sha512-e+uPbPHqTQWKyCX435uVlOmgH9tUt0xtjvyOC7knhKgOS643BrQKuTo+KecGpPV7qlmOyZgCfaM4xxPWtDEN/g==",
+    "@popperjs/core": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
       "dev": true
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+    "bootstrap": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "homepage": "https://github.com/technology-toolbox/techtoolbox-hugo#readme",
   "devDependencies": {
-    "bootstrap": "^5.0.0-beta2",
-    "popper.js": "^1.16.1"
-  }
+    "@popperjs/core": "^2.10.2",
+    "bootstrap": "^5.1.3"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
- Remove Bootstrap v5 Beta 2 packages:

  npm uninstall bootstrap@next
  npm uninstall popper.js

- Add latest Bootstrap 5 packages:

  npm install bootstrap --save-dev
  npm install popper.js --save-dev

Modify imports to match Bootstrap 5.1.3 "main" Sass file