### PR TITLE
Upgrade Bootstrap script bundle and Bootstrap Icons and switch to Cloudflare

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -13,9 +13,10 @@
 
 <!-- Scripts for Bootstrap -->
 <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0"
-    crossorigin="anonymous"></script>
+    src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"
+    integrity="sha512-pax4MlgXjHEPfCwcJLQhigY7+N8rt6bVvWLFyUMuxShv170X53TRzGPmPkZmGBhk+jikR8WBM4yl7A9WMHHqvg=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"></script>
 <!-- Scripts for placeholder images -->
 <script
     src="https://cdnjs.cloudflare.com/ajax/libs/holder/2.9.7/holder.min.js"

--- a/layouts/partials/stylesheet.html
+++ b/layouts/partials/stylesheet.html
@@ -13,5 +13,9 @@
 {{- end }}
 <link rel="stylesheet" href="{{ $style.Permalink | relURL }}">
 
-<link rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css">
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.7.0/font/bootstrap-icons.min.css"
+  integrity="sha512-yLNTU6YQWEtsM/WVkUqd2jRzzq5hmfFUMVvziVlkgC0R9HTElDtyF4DiWiBeMS36npvN+NWwrr764A4AWGcmQQ=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer" />


### PR DESCRIPTION
Switching to Cloudflare CDN (instead of jsDelivr) will simplify the Content-Security-Policy HTTP header (technology-toolbox/website#90)