### PR TITLE
Add Bootstrap SVG icon - arrow-up-right-square

### DIFF
--- a/assets/svg-icons/arrow-up-right-square.svg
+++ b/assets/svg-icons/arrow-up-right-square.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="svg-icon arrow-up-right-square" width="16" height="16" role="img" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707l-4.096 4.096z"/>
+</svg>


### PR DESCRIPTION
Issue #32

**Note:** While this icon is not currently used in the theme, it is used in numerous blog posts on the website. Adding it to the theme makes more sense than adding it to the website (since the Hugo `resources.Get` function will search in the **assets** folder of the theme). This way, all of the SVG icons are kept in one location.